### PR TITLE
Remove file upload option from Request a Quote form

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,12 +207,6 @@
                                 <label for="description" class="block text-gray-700 font-semibold mb-2">Job Description</label>
                                 <textarea id="description" name="description" rows="6" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500" required placeholder="Describe the work you need done. For example: 'I need to repair a crumbling section of my brick chimney.' or 'I would like a quote for a new 12x15 foot paver patio.'"></textarea>
                             </div>
-                            <!-- File Upload -->
-                            <div class="md:col-span-2">
-                                <label for="jobPhotos" class="block text-gray-700 font-semibold mb-2">Add Pictures (Optional)</label>
-                                <input type="file" id="jobPhotos" name="jobPhotos" multiple class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-amber-50 file:text-amber-700 hover:file:bg-amber-100" accept="image/*">
-                                <p class="text-xs text-gray-500 mt-1">You can upload up to 5 images (JPG, PNG).</p>
-                            </div>
                         </div>
                         <div class="text-center mt-8">
                             <button type="submit" class="bg-amber-600 hover:bg-amber-700 text-white font-bold py-3 px-12 rounded-lg transition duration-300">Submit Request</button>


### PR DESCRIPTION
This commit removes the HTML section related to file uploads from the 'Request a Quote' form in `index.html`. You requested the removal of this feature.